### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,29 @@
-/_build
-/deps
-/bench/snapshots
-/doc
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Ignore package tarball (built via "mix hex.build").
+hashids-*.tar
+
+# Temporary files for e.g. tests.
+/tmp/
+
+# Misc.
+/bench/snapshots/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: elixir
 
 otp_release:
     - 19.1
-    
+
 elixir:
     - 1.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,4 @@ Changelog
 
 ## v1.0.0 – Oct 26, 2014
 
-  * initial release on hex.pm
+  * Initial release on hex.pm.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014–2015 Alexei Sholik <alcosholik@gmail.com>
+Copyright (c) 2014 Alexei Sholik <alcosholik@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@ Hashids
 =======
 
 [![Build status](https://travis-ci.org/alco/hashids-elixir.svg "Build status")](https://travis-ci.org/alco/hashids-elixir)
-[![Hex version](https://img.shields.io/hexpm/v/hashids.svg "Hex version")](https://hex.pm/packages/hashids)
-![Hex downloads](https://img.shields.io/hexpm/dt/hashids.svg "Hex downloads")
+[![Module Version](https://img.shields.io/hexpm/v/hashids.svg)](https://hex.pm/packages/hashids)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/hashids/)
+[![Total Download](https://img.shields.io/hexpm/dt/hashids.svg)](https://hex.pm/packages/hashids)
+[![License](https://img.shields.io/hexpm/l/hashids.svg)](https://github.com/alco/hashids-elixir/blob/master/LICENSE.md)
+[![Last Updated](https://img.shields.io/github/last-commit/alco/hashids-elixir.svg)](https://github.com/alco/hashids/commits/master)
+
 
 Hashids lets you obfuscate numerical identifiers via reversible mapping.
 
@@ -18,7 +22,9 @@ Add Hashids as a dependency to your Mix project:
 
 ```elixir
 defp deps do
-  [{:hashids, "~> 2.0"}]
+  [
+    {:hashids, "~> 2.0"}
+  ]
 end
 ```
 
@@ -74,8 +80,10 @@ MyAccessToken.decode(data)
 
 ## Migrating from 1.0
 
-See the [changelog](CHANGELOG.md).
+See the [changelog](./CHANGELOG.md).
 
-## License
+## Copyright and License
 
-This software is licensed under [the MIT license](LICENSE).
+Copyright (c) 2014 Alexei Sholik
+
+This software is licensed under [the MIT license](./LICENSE.md).

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,7 @@
 defmodule Hashids.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/alco/hashids-elixir"
   @version "2.0.4"
 
   def project do
@@ -9,27 +10,20 @@ defmodule Hashids.Mixfile do
       version: @version,
       elixir: "~> 1.5",
       deps: deps(),
-      description: description(),
       package: package(),
-      source_url: "https://github.com/alco/hashids-elixir",
-      docs: [
-        main: Hashids,
-        source_ref: "v#{@version}",
-      ],
+      docs: docs()
     ]
-  end
-
-  defp description do
-    "Hashids lets you obfuscate numerical identifiers via reversible mapping."
   end
 
   defp package do
     [
-      files: ["lib", "mix.exs", "README.md", "LICENSE", "CHANGELOG.md"],
+      description: "Hashids lets you obfuscate numerical identifiers via reversible mapping.",
+      files: ["lib", "mix.exs", "README.md", "LICENSE.md", "CHANGELOG.md"],
       maintainers: ["Alexei Sholik"],
       licenses: ["MIT"],
       links: %{
-        "GitHub" => "https://github.com/alco/hashids-elixir",
+        "Changelog" => "https://hexdocs.pm/hashids/changelog.html",
+        "GitHub" => @source_url
       }
     ]
   end
@@ -37,7 +31,17 @@ defmodule Hashids.Mixfile do
   defp deps do
     [
       {:benchfella, "~> 0.2", only: :bench},
-      {:ex_doc, "> 0.0.0", only: :dev},
+      {:ex_doc, "> 0.0.0", only: :dev, runtime: false},
+    ]
+  end
+
+  defp docs do
+    [
+      extras: ["CHANGELOG.md", {:"LICENSE.md", [title: "License"]}, "README.md"],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: "v#{@version}",
+      formatters: ["html"]
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,10 @@
 %{
-  "benchfella": {:hex, :benchfella, "0.3.1", "3728b082725f27c46502c4609f78b8db01d4739932ebfc59f350b7a2b47d394d", [:mix], []},
-  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.19.2", "6f4081ccd9ed081b6dc0bd5af97a41e87f5554de469e7d76025fba535180565f", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "benchfella": {:hex, :benchfella, "0.3.1", "3728b082725f27c46502c4609f78b8db01d4739932ebfc59f350b7a2b47d394d", [:mix], [], "hexpm", "55c5f066bbe6fbddc6de6293f9f36c9d1000fa14a67d24d32801d8ac612f55e0"},
+  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm", "000aaeff08919e95e7aea13e4af7b2b9734577b3e6a7c50ee31ee88cab6ec4fb"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.12", "b245e875ec0a311a342320da0551da407d9d2b65d98f7a9597ae078615af3449", [:mix], [], "hexpm", "711e2cc4d64abb7d566d43f54b78f7dc129308a63bc103fbd88550d2174b3160"},
+  "ex_doc": {:hex, :ex_doc, "0.24.2", "e4c26603830c1a2286dae45f4412a4d1980e1e89dc779fcd0181ed1d5a05c8d9", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "e134e1d9e821b8d9e4244687fb2ace58d479b67b282de5158333b0d57c6fb7da"},
+  "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.15.1", "b5888c880d17d1cc3e598f05cdb5b5a91b7b17ac4eaf5f297cb697663a1094dd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "db68c173234b07ab2a07f645a5acdc117b9f99d69ebf521821d89690ae6c6ec8"},
+  "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
 }


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the main source doc for this Elixir
library which leverage on latest ExDoc features.